### PR TITLE
Assertions fail on missing property matchers

### DIFF
--- a/json-fixtures-lib/src/main/java/ie/corballis/fixtures/assertion/PropertyMatcherVisitor.java
+++ b/json-fixtures-lib/src/main/java/ie/corballis/fixtures/assertion/PropertyMatcherVisitor.java
@@ -10,16 +10,26 @@ import static java.util.stream.Collectors.toList;
 public abstract class PropertyMatcherVisitor implements JsonNodeVisitor {
 
     protected final List<String> propertyChain;
+    private boolean matched;
 
     public PropertyMatcherVisitor(List<String> propertyChain) {
         this.propertyChain = propertyChain;
     }
 
     protected boolean isMatchingPath(Stack<Object> path) {
-        return convertToMatcherProperties(path).equals(propertyChain);
+        boolean matched = convertToMatcherProperties(path).equals(propertyChain);
+        if (matched) {
+            this.matched = true;
+        }
+        return matched;
     }
 
     protected List<Object> convertToMatcherProperties(Stack<Object> stack) {
         return stack.stream().filter(value -> value instanceof String).collect(toList());
     }
+
+    public boolean isMatched() {
+        return matched;
+    }
+
 }

--- a/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/FixtureAssertSnapshotsTest.fixtures.json
+++ b/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/FixtureAssertSnapshotsTest.fixtures.json
@@ -151,5 +151,9 @@
     "intProperty": 1,
     "listProperty": null,
     "nested": null
+  },
+  "assertionShouldNotDisplayOverriddenProperties-1": {
+    "stringProperty": "property2",
+    "nested": null
   }
 }

--- a/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/FixtureAssertSnapshotsTest.java
+++ b/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/FixtureAssertSnapshotsTest.java
@@ -9,6 +9,7 @@ import ie.corballis.fixtures.io.write.SnapshotFixtureWriter;
 import ie.corballis.fixtures.settings.Settings;
 import org.apache.commons.io.FileUtils;
 import org.fest.assertions.api.Assertions;
+import org.hamcrest.Matchers;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import static ie.corballis.fixtures.assertion.FixtureAssert.assertThat;
+import static ie.corballis.fixtures.assertion.PropertyMatchers.overriddenMatchers;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -150,6 +152,32 @@ public class FixtureAssertSnapshotsTest {
             assertThat(bean2).toMatchSnapshotExactly();
         } catch (ComparisonFailure e) {
             assertFailureMessage(e, "toMatchSnapshotExactlyShouldFailWhenExistingSnapshotChanged");
+            return;
+        }
+
+        Assertions.fail("Fixture assertion should have been failed");
+    }
+
+    @Test
+    public void assertionShouldNotDisplayOverriddenProperties() throws Exception {
+        init();
+
+        try {
+            assertThat(bean).toMatchSnapshotExactly(overriddenMatchers("intProperty",
+                                                                       Matchers.anything(),
+                                                                       "stringProperty",
+                                                                       Matchers.anything()));
+        } catch (ComparisonFailure e) {
+            assertFailureMessage(e, "assertionShouldNotDisplayOverriddenProperties");
+            Assertions.assertThat(e.getActual())
+                      .isEqualTo("'{\n" +
+                                 "  \"listProperty\": [\n" +
+                                 "    \"element1\",\n" +
+                                 "    \"element2\",\n" +
+                                 "    \"element3\"\n" +
+                                 "  ],\n" +
+                                 "  \"nested\": null\n" +
+                                 "}'");
             return;
         }
 

--- a/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/FixtureAssertTest.java
+++ b/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/FixtureAssertTest.java
@@ -20,10 +20,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static ie.corballis.fixtures.util.StringUtils.unifyLineEndings;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static ie.corballis.fixtures.util.StringUtils.unifyLineEndings;
-
 
 @RunWith(MockitoJUnitRunner.class)
 public class FixtureAssertTest {
@@ -70,6 +69,12 @@ public class FixtureAssertTest {
             System.out.println(e.getMessage());
             assertFailureMessage(e, "expectedMessage1");
         }
+    }
+
+    private void assertFailureMessage(ComparisonFailure e, String relativePath) throws URISyntaxException, IOException {
+        URI uri = getClass().getClassLoader().getResource(relativePath).toURI();
+        String expectedMessage = FileUtils.readFileToString(new File(uri));
+        Assertions.assertThat(unifyLineEndings(e.getMessage())).isEqualTo(unifyLineEndings(expectedMessage));
     }
 
     @Test
@@ -127,7 +132,8 @@ public class FixtureAssertTest {
     public void matchesExactlyWithStrictOrder_doesNotAllowAnyOrdering() throws URISyntaxException, IOException {
         try {
             bean3.setListProperty(newArrayList("element2", "element1", "element3"));
-            FixtureAssert.assertThat(bean3).matchesExactlyWithStrictOrder("fixture1", "fixture2", "fixture3", "fixture5");
+            FixtureAssert.assertThat(bean3)
+                         .matchesExactlyWithStrictOrder("fixture1", "fixture2", "fixture3", "fixture5");
         } catch (ComparisonFailure e) {
             assertFailureMessage(e, "expectedMessage4");
         }
@@ -138,12 +144,6 @@ public class FixtureAssertTest {
         FixtureAssert.assertThat(bean3).matchesExactlyWithStrictOrder("fixture1", "fixture2", "fixture3", "fixture5");
     }
 
-    private void assertFailureMessage(ComparisonFailure e, String relativePath) throws URISyntaxException, IOException {
-        URI uri = getClass().getClassLoader().getResource(relativePath).toURI();
-        String expectedMessage = FileUtils.readFileToString(new File(uri));
-        Assertions.assertThat(unifyLineEndings(e.getMessage())).isEqualTo(unifyLineEndings(expectedMessage));
-    }
-
     @Test
     public void toMatchSnapshotShouldGenerateNewFileForFirstTime() throws IOException {
         FixtureAssert.assertThat(bean).toMatchSnapshot();
@@ -151,4 +151,5 @@ public class FixtureAssertTest {
                                                       "toMatchSnapshotShouldGenerateNewFileForFirstTime-1",
                                                       bean);
     }
+
 }

--- a/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/PropertyMatchersTest.fixtures.json
+++ b/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/PropertyMatchersTest.fixtures.json
@@ -269,5 +269,14 @@
   "shouldFailWhenNestedPropertyMatcherIsNotTheSameClassAsExpected-1": {
     "age": 1,
     "cars": []
+  },
+  "shouldFailWhenPropertyNotFoundInActualEntity-1": {
+    "age": 1,
+    "dog": {
+      "name": "XXX",
+      "age": 3.23,
+      "breed": "labrador"
+    },
+    "cars": []
   }
 }

--- a/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/PropertyMatchersTest.java
+++ b/json-fixtures-lib/src/test/java/ie/corballis/fixtures/assertion/PropertyMatchersTest.java
@@ -91,6 +91,32 @@ public class PropertyMatchersTest {
     }
 
     @Test
+    public void shouldFailWhenPropertyNotFoundInActualEntity() throws IOException {
+        expectedException.expectMessage("The following properties [cat, createdBy] could not be found in Person. " +
+                                        "Please check that you provided the correct path to the property you want to match with.");
+        FixtureAssert.assertThat(person1)
+                     .toMatchSnapshotExactlyWithStrictOrder(overriddenMatchers("cat",
+                                                                               any(Object.class),
+                                                                               "age",
+                                                                               anything(),
+                                                                               "createdBy",
+                                                                               anything()));
+    }
+
+    @Test
+    public void shouldFailWhenNestedPropertyNotFoundInActualEntity() throws IOException {
+        expectedException.expectMessage("The following properties [x.a.b.F] could not be found in LinkedHashMap. " +
+                                        "Please check that you provided the correct path to the property you want to match with.");
+        FixtureAssert.assertThat(testMap)
+                     .matchesExactlyWithStrictOrder(overriddenMatchers("b.a",
+                                                                       anything(),
+                                                                       "x.a.b",
+                                                                       equalTo(1),
+                                                                       "x.a.b.F",
+                                                                       anything()), "testMapExpected");
+    }
+
+    @Test
     public void propertyMatchersShouldNotMatchWithNestedObject() throws IOException {
         expectedException.expectMessage("Property 'dog' did not match with the PropertyMatcher you provided.");
         FixtureAssert.assertThat(person1)
@@ -148,11 +174,6 @@ public class PropertyMatchersTest {
         expectedException.expectMessage("Expected: <20>");
         expectedException.expectMessage("but: was <1>");
         FixtureAssert.assertThat(person1).matchesExactly(overriddenMatchers("age", equalTo(20)), "person1");
-    }
-
-    @Test
-    public void shouldNotFailWhenMatcherDoesNotExistForProperty() throws Exception {
-        FixtureAssert.assertThat(person1).matchesExactly(overriddenMatchers("dog.x", equalTo(20)), "person1");
     }
 
     @Test

--- a/json-fixtures-lib/src/test/resources/assertionShouldNotDisplayOverriddenProperties
+++ b/json-fixtures-lib/src/test/resources/assertionShouldNotDisplayOverriddenProperties
@@ -1,0 +1,11 @@
+expected:<'{
+  "[stringProperty": "property2"],
+  "nested": null
+}...> but was:<'{
+  "[listProperty": [
+    "element1",
+    "element2",
+    "element3"
+  ]],
+  "nested": null
+}...>


### PR DESCRIPTION
- assertions fails when overridden properties are missing from the actual entity

- assertion result is now much clearer and does not include overridden properties