### PR TITLE
Allow for merging of fixture lists

### DIFF
--- a/json-fixtures-lib/src/main/java/ie/corballis/fixtures/core/BeanFactory.java
+++ b/json-fixtures-lib/src/main/java/ie/corballis/fixtures/core/BeanFactory.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Joiner;
 import com.google.common.cache.Cache;
@@ -168,6 +169,11 @@ public class BeanFactory {
 
     private static JsonNode merge(JsonNode targetNode, JsonNode sourceNode) {
         Iterator<String> fieldNames = sourceNode.fieldNames();
+        if (!fieldNames.hasNext() && sourceNode.isArray() && !targetNode.fieldNames().hasNext() && targetNode.isArray()) {
+            if (targetNode instanceof ArrayNode) {
+                ((ArrayNode) targetNode).addAll( (ArrayNode)sourceNode );
+            }
+        }
         while (fieldNames.hasNext()) {
             String fieldName = fieldNames.next();
             JsonNode jsonNode = targetNode.get(fieldName);

--- a/json-fixtures-lib/src/test/java/ie/corballis/fixtures/core/BeanFactoryTest.java
+++ b/json-fixtures-lib/src/test/java/ie/corballis/fixtures/core/BeanFactoryTest.java
@@ -2,6 +2,7 @@ package ie.corballis.fixtures.core;
 
 import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.SimpleType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import ie.corballis.fixtures.io.ClassPathResource;
 import ie.corballis.fixtures.io.DefaultFixtureReader;
 import ie.corballis.fixtures.settings.Settings;
@@ -135,5 +136,13 @@ public class BeanFactoryTest {
                                              NEW_LINE +
                                              "  }" + NEW_LINE +
                                              "}");
+    }
+
+    @Test
+    public void canMergeLists() {
+        CollectionType collectionType = TypeFactory.defaultInstance().constructCollectionType(List.class, MyBean.class);
+        List<MyBean> beans = factory.create(collectionType, "fixture6", "fixture7");
+        assertThat(beans.size()).isEqualTo(4);
+        assertThat(beans).contains(new MyBean("property4",4));
     }
 }

--- a/json-fixtures-lib/src/test/java/ie/corballis/fixtures/io/DefaultFixtureReaderTest.java
+++ b/json-fixtures-lib/src/test/java/ie/corballis/fixtures/io/DefaultFixtureReaderTest.java
@@ -23,6 +23,7 @@ public class DefaultFixtureReaderTest {
                                                   "fixture5={\"nested\":{\"prop1\":\"value\"}}, " +
                                                   "fixture6=[{\"stringProperty\":\"property1\",\"intProperty\":1}," +
                                                   "{\"stringProperty\":\"property2\",\"intProperty\":2}," +
-                                                  "{\"stringProperty\":\"property3\",\"intProperty\":3}]}");
+                                                  "{\"stringProperty\":\"property3\",\"intProperty\":3}], " +
+                                                  "fixture7=[{\"stringProperty\":\"property4\",\"intProperty\":4}]}");
     }
 }

--- a/json-fixtures-lib/src/test/resources/test2.fixtures.json
+++ b/json-fixtures-lib/src/test/resources/test2.fixtures.json
@@ -39,5 +39,12 @@
         "stringProperty": "property3",
         "intProperty": 3
       }
+    ],
+
+    "fixture7": [
+      {
+        "stringProperty": "property4",
+        "intProperty": 4
+      }
     ]
 }


### PR DESCRIPTION
Hello,

I have a case where I want to merge lists of data so that I have a base list of beans and then I don't have to redefine this whole list for another tests case, just append some items.

Unless I have missed some way of doing this which already exists? I have prepared some code with a simple test to at least show my use-case.